### PR TITLE
Add Task Stage for Calculating Recall Under Churn

### DIFF
--- a/script/utils/preprocessing.py
+++ b/script/utils/preprocessing.py
@@ -73,6 +73,12 @@ def process_result_file(result_file_path: str, data_result: dict) -> dict:
         data_result["concurrency_duration"] = (
             result["task_config"]["case_config"]["concurrency_search_config"]["concurrency_duration"]
         )
+        data_result["p_churn"] = (
+            result["task_config"]["case_config"]["churn_search_config"]["p_churn"]
+        )
+        data_result["cycles"] = (
+            result["task_config"]["case_config"]["churn_search_config"]["cycles"]
+        )
         data_result.update(result["metrics"])
         data_result["create_index_after_load"] = result["task_config"]["db_case_config"]["create_index_after_load"]
         data_result["create_index_before_load"] = result["task_config"]["db_case_config"]["create_index_before_load"]

--- a/vectordb_bench/__init__.py
+++ b/vectordb_bench/__init__.py
@@ -51,9 +51,11 @@ class config:
     OPTIMIZE_TIMEOUT_768D_10M   = 5 * 3600 # 5h
     OPTIMIZE_TIMEOUT_768D_100M  =  50 * 3600 # 50h
 
-
     OPTIMIZE_TIMEOUT_1536D_500K =  300 * 60   # 300min
     OPTIMIZE_TIMEOUT_1536D_5M   =   5 * 3600 # 5h
+
+    CHURN_CYCLES_DEFAULT = 0 # Keeping this default to 0 as most clients do not support churn
+    CHURN_P_CHURN_DEFAULT = 10
     def display(self) -> str:
         tmp = [
             i for i in inspect.getmembers(self)

--- a/vectordb_bench/backend/cases.py
+++ b/vectordb_bench/backend/cases.py
@@ -72,7 +72,7 @@ class CaseType(Enum):
 class CaseLabel(Enum):
     Load = auto()
     Performance = auto()
-
+    Churn = auto()
 
 class Case(BaseModel):
     """Undefined case
@@ -83,6 +83,8 @@ class Case(BaseModel):
         dataset(DataSet): dataset for this case runner.
         filter_rate(float | None): one of 99% | 1% | None
         filters(dict | None): filters for search
+        cycles(float | None): number of times to run churn cycles
+        p_churn(float | None): % of data to delete and reinsert
     """
 
     case_id: CaseType
@@ -95,6 +97,8 @@ class Case(BaseModel):
     optimize_timeout: float | int | None = None
 
     filter_rate: float | None = None
+    cycles: int | None = None
+    p_churn: float | int | None = None
 
     @property
     def filters(self) -> dict | None:

--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -169,6 +169,24 @@ class VectorDB(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs,
+    ) -> (int, Exception):
+        """Delete embeddings from the vector database based on metadata.
+
+        Args:
+            metadata (list[int]): List of metadata associated with the embeddings to delete.
+            **kwargs (Any): Vector database specific parameters.
+
+        Returns:
+            int: Number of deleted embeddings.
+            Exception: An exception if any error occurred during deletion.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def search_embedding(
         self,
         query: list[float],

--- a/vectordb_bench/backend/runner/serial_runner.py
+++ b/vectordb_bench/backend/runner/serial_runner.py
@@ -248,59 +248,61 @@ class SerialChurnRunner:
         churn_size = int(total_embeddings * self.p_churn)
 
         log.info(f"Starting churn process with total embeddings: {total_embeddings}, churn size: {churn_size}")
-        
-        # Calculate recall before the first deletion/insertion cycle
-        log.info("Calculating initial metrics (recall, NDCG, p99 latency) before churn.")
-        initial_recall, initial_ndcg, initial_p99 = self._calculate_metrics()
-        results.append({
-            'cycle': 0,  # Pre-churn cycle
-            'recall': initial_recall,
-            'ndcg': initial_ndcg,
-            'p99': initial_p99
-        })
-        log.info(f"Initial metrics calculated: recall={initial_recall}, NDCG={initial_ndcg}, p99 latency={initial_p99}")
 
-        # Perform the delete/insert churn for the defined number of cycles
-        for cycle in range(1, self.cycles + 1):
-            log.info(f"Starting cycle {cycle}/{self.cycles}.")
-            
-            # Randomly select embeddings to delete
-            log.info(f"Selecting {churn_size} embeddings to delete for cycle {cycle}.")
-            deleted_embeddings, deleted_metadata = self._select_random_embeddings()
-            
-            # Delete selected embeddings
-            log.info(f"Deleting {len(deleted_metadata)} embeddings in cycle {cycle}.")
-            deleted_count, delete_error = self._delete_embeddings(deleted_metadata)
-            if delete_error:
-                log.error(f"Failed to delete embeddings in cycle {cycle}, error: {delete_error}")
-            else:
-                log.info(f"Successfully deleted {deleted_count} embeddings in cycle {cycle}.")
-
-            # Re-insert deleted embeddings
-            log.info(f"Re-inserting {len(deleted_embeddings)} embeddings in cycle {cycle}.")
-            inserted_count, insert_error = self._insert_embeddings(deleted_embeddings, deleted_metadata)
-            if insert_error:
-                log.error(f"Failed to insert embeddings in cycle {cycle}, error: {insert_error}")
-            else:
-                log.info(f"Successfully inserted {inserted_count} embeddings in cycle {cycle}.")
-
-            # Perform a search to calculate metrics
-            log.info(f"Calculating metrics (recall, NDCG, p99 latency) after re-insertion in cycle {cycle}.")
-            recall, ndcg, p99 = self._calculate_metrics()
-            
-            # Store results for the cycle
+        # Initialize the database connection once
+        with self.db.init():
+            # Calculate recall before the first deletion/insertion cycle
+            log.info("Calculating initial metrics (recall, NDCG, p99 latency) before churn.")
+            initial_recall, initial_ndcg, initial_p99 = self._calculate_metrics()
             results.append({
-                'cycle': cycle,
-                'recall': recall,
-                'ndcg': ndcg,
-                'p99': p99
+                'cycle': 0,  # Pre-churn cycle
+                'recall': initial_recall,
+                'ndcg': initial_ndcg,
+                'p99': initial_p99
             })
-            log.info(f"Cycle {cycle} completed: recall={recall}, NDCG={ndcg}, p99 latency={p99}")
+            log.info(f"Initial metrics calculated: recall={initial_recall}, NDCG={initial_ndcg}, p99 latency={initial_p99}")
+
+            # Perform the delete/insert churn for the defined number of cycles
+            for cycle in range(1, self.cycles + 1):
+                log.info(f"Starting cycle {cycle}/{self.cycles}.")
+                
+                # Randomly select embeddings to delete
+                log.info(f"Selecting {churn_size} embeddings to delete for cycle {cycle}.")
+                deleted_embeddings, deleted_metadata = self._select_random_embeddings()
+                
+                # Delete selected embeddings
+                log.info(f"Deleting {len(deleted_metadata)} embeddings in cycle {cycle}.")
+                deleted_count, delete_error = self.db.delete_embeddings(deleted_metadata)
+                if delete_error:
+                    log.error(f"Failed to delete embeddings in cycle {cycle}, error: {delete_error}")
+                else:
+                    log.info(f"Successfully deleted {deleted_count} embeddings in cycle {cycle}.")
+
+                # Re-insert deleted embeddings
+                log.info(f"Re-inserting {len(deleted_embeddings)} embeddings in cycle {cycle}.")
+                inserted_count, insert_error = self.db.insert_embeddings(deleted_embeddings, deleted_metadata)
+                if insert_error:
+                    log.error(f"Failed to insert embeddings in cycle {cycle}, error: {insert_error}")
+                else:
+                    log.info(f"Successfully inserted {inserted_count} embeddings in cycle {cycle}.")
+
+                # Perform a search to calculate metrics
+                log.info(f"Calculating metrics (recall, NDCG, p99 latency) after re-insertion in cycle {cycle}.")
+                recall, ndcg, p99 = self._calculate_metrics()
+                
+                # Store results for the cycle
+                results.append({
+                    'cycle': cycle,
+                    'recall': recall,
+                    'ndcg': ndcg,
+                    'p99': p99
+                })
+                log.info(f"Cycle {cycle} completed: recall={recall}, NDCG={ndcg}, p99 latency={p99}")
 
         log.info("Churn process completed.")
         return results
 
-    
+
     def _select_random_embeddings(self) -> tuple[list[list[float]], list[int]]:
         """Selects random embeddings and metadata for deletion based on self.p_churn."""
         selected_embeddings = []
@@ -347,16 +349,6 @@ class SerialChurnRunner:
         log.info(f"Selected {len(selected_embeddings)} embeddings out of {total_embeddings} total embeddings, with a churn size of {churn_size}.")
 
         return selected_embeddings, selected_metadata
-
-    def _delete_embeddings(self, metadata: list[int]):
-        """Deletes embeddings from the database."""
-        with self.db.init():
-            self.db.delete_embeddings(metadata)
-
-    def _insert_embeddings(self, embeddings: list[list[float]], metadata: list[int]):
-        """Inserts embeddings back into the database."""
-        with self.db.init():
-            self.db.insert_embeddings(embeddings, metadata)
 
     def _calculate_metrics(self) -> tuple[float, float, float]:
         """Calculates recall, NDCG, and latency metrics."""

--- a/vectordb_bench/backend/runner/serial_runner.py
+++ b/vectordb_bench/backend/runner/serial_runner.py
@@ -250,20 +250,20 @@ class SerialChurnRunner:
         log.info(f"Starting churn process with total embeddings: {total_embeddings}, churn size: {churn_size}")
 
         # Initialize the database connection once
-        with self.db.init():
-            # Calculate recall before the first deletion/insertion cycle
-            log.info("Calculating initial metrics (recall, NDCG, p99 latency) before churn.")
-            initial_recall, initial_ndcg, initial_p99 = self._calculate_metrics()
-            results.append({
-                'cycle': 0,  # Pre-churn cycle
-                'recall': initial_recall,
-                'ndcg': initial_ndcg,
-                'p99': initial_p99
-            })
-            log.info(f"Initial metrics calculated: recall={initial_recall}, NDCG={initial_ndcg}, p99 latency={initial_p99}")
+        # Calculate recall before the first deletion/insertion cycle
+        log.info("Calculating initial metrics (recall, NDCG, p99 latency) before churn.")
+        initial_recall, initial_ndcg, initial_p99 = self._calculate_metrics()
+        results.append({
+            'cycle': 0,  # Pre-churn cycle
+            'recall': initial_recall,
+            'ndcg': initial_ndcg,
+            'p99': initial_p99
+        })
+        log.info(f"Initial metrics calculated: recall={initial_recall}, NDCG={initial_ndcg}, p99 latency={initial_p99}")
 
-            # Perform the delete/insert churn for the defined number of cycles
-            for cycle in range(1, self.cycles + 1):
+        # Perform the delete/insert churn for the defined number of cycles
+        for cycle in range(1, self.cycles + 1):
+            with self.db.init():
                 log.info(f"Starting cycle {cycle}/{self.cycles}.")
                 
                 # Randomly select embeddings to delete
@@ -288,16 +288,16 @@ class SerialChurnRunner:
 
                 # Perform a search to calculate metrics
                 log.info(f"Calculating metrics (recall, NDCG, p99 latency) after re-insertion in cycle {cycle}.")
-                recall, ndcg, p99 = self._calculate_metrics()
-                
-                # Store results for the cycle
-                results.append({
-                    'cycle': cycle,
-                    'recall': recall,
-                    'ndcg': ndcg,
-                    'p99': p99
-                })
-                log.info(f"Cycle {cycle} completed: recall={recall}, NDCG={ndcg}, p99 latency={p99}")
+            recall, ndcg, p99 = self._calculate_metrics()
+            
+            # Store results for the cycle
+            results.append({
+                'cycle': cycle,
+                'recall': recall,
+                'ndcg': ndcg,
+                'p99': p99
+            })
+            log.info(f"Cycle {cycle} completed: recall={recall}, NDCG={ndcg}, p99 latency={p99}")
 
         log.info("Churn process completed.")
         return results

--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -243,7 +243,7 @@ class CaseRunner(BaseModel):
             - 'p99' (float): The 99th percentile of search latency (in seconds) after each cycle.
         """
         try:
-            return self.serial_churn_runner.run()
+            return self.churn_runner.run()
         except Exception as e:
             log.warning(f"search error: {str(e)}, {e}")
             raise e from None

--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -52,7 +52,7 @@ class CaseRunner(BaseModel):
     db: api.VectorDB | None = None
     test_emb: list[list[float]] | None = None
     serial_search_runner: SerialSearchRunner | None = None
-    serial_churn_runner: SerialChurnRunner | None = None
+    churn_runner: SerialChurnRunner | None = None
     search_runner: MultiProcessingSearchRunner | None = None
     final_search_runner: MultiProcessingSearchRunner | None = None
 

--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -194,7 +194,8 @@ class CaseRunner(BaseModel):
                     m.qps, m.conc_num_list, m.conc_qps_list, m.conc_latency_p99_list = search_results
                 if (TaskStage.CHURN in self.config.stages):
                     search_results = self._churn_search()
-                    m.qps, m.conc_num_list, m.conc_qps_list, m.conc_latency_p99_list = search_results
+                    #TODO add these to metric
+                    #m.qps, m.conc_num_list, m.conc_qps_list, m.conc_latency_p99_list = search_results
             
         except Exception as e:
             log.warning(f"Failed to run performance case, reason = {e}")
@@ -314,8 +315,8 @@ class CaseRunner(BaseModel):
                 dataset=self.ca.dataset,
                 test_data=self.test_emb,
                 ground_truth=gt_df,
-                p_churn=self.config.case_config.churn_config.p_churn,  # Churn percentage
-                cycles=self.config.case_config.churn_config.cycles,    # Number of churn cycles
+                p_churn=self.config.case_config.churn_search_config.p_churn,  # Churn percentage
+                cycles=self.config.case_config.churn_search_config.cycles,    # Number of churn cycles
                 normalize=self.normalize,
                 k=self.config.case_config.k,
             )

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -132,6 +132,7 @@ def parse_task_stages(
     load: bool,
     search_serial: bool,
     search_concurrent: bool,
+    search_churn: bool
 ) -> List[TaskStage]:
     stages = []
     if load and not drop_old:
@@ -146,6 +147,8 @@ def parse_task_stages(
         stages.append(TaskStage.SEARCH_SERIAL)
     if search_concurrent:
         stages.append(TaskStage.SEARCH_CONCURRENT)
+    if search_churn:
+        stages.append(TaskStage.CHURN)
     return stages
 
 
@@ -230,6 +233,16 @@ class CommonTypedDict(TypedDict):
             type=bool,
             default=True,
             help="Search concurrent or skip",
+            show_default=True,
+        ),
+    ]
+    search_churn: Annotated[
+        bool,
+        click.option(
+            "--search-churn/--skip-search-churn",
+            type=bool,
+            default=True,
+            help="Test index churn or skip",
             show_default=True,
         ),
     ]
@@ -488,6 +501,7 @@ def run(
             parameters["load"],
             parameters["search_serial"],
             parameters["search_concurrent"],
+            parameters["search_churn"],
         ),
     )
 

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -25,6 +25,7 @@ from ..interface import benchMarkRunner, global_result_future
 from ..models import (
     CaseConfig,
     CaseType,
+    ChurnSearchConfig,
     ConcurrencySearchConfig,
     DBCaseConfig,
     DBConfig,
@@ -305,6 +306,24 @@ class CommonTypedDict(TypedDict):
             callback=lambda *args: list(map(int, click_arg_split(*args))),
         ),
     ]
+    p_churn: Annotated[
+        float,
+        click.option(
+            "--p-churn",
+            help="Percentage of churn",
+            default=10.0,  # Default to 10% churn
+            show_default=True,
+        ),
+    ]
+    cycles: Annotated[
+        int,
+        click.option(
+            "--cycles",
+            help="Number of churn cycles to perform",
+            default=1,  # Default to 1 cycle
+            show_default=True,
+        ),
+    ]
     custom_case_name: Annotated[
         str,
         click.option(
@@ -491,6 +510,10 @@ def run(
             concurrency_search_config=ConcurrencySearchConfig(
                 concurrency_duration=parameters["concurrency_duration"],
                 num_concurrency=[int(s) for s in parameters["num_concurrency"]],
+            ),
+            churn_search_config=ChurnSearchConfig(
+                p_churn=parameters["p_churn"],
+                cycles=parameters["cycles"],
             ),
             custom_case=parameters["custom_case"],
         ),

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -83,6 +83,9 @@ class ConcurrencySearchConfig(BaseModel):
     num_concurrency: List[int] = config.NUM_CONCURRENCY
     concurrency_duration: int = config.CONCURRENCY_DURATION
 
+class ChurnSearchConfig(BaseModel):
+    p_churn: float = config.CHURN_P_CHURN_DEFAULT
+    cycles: int = config.CHURN_CYCLES_DEFAULT
 
 class CaseConfig(BaseModel):
     """cases, dataset, test cases, filter rate, params"""
@@ -91,6 +94,7 @@ class CaseConfig(BaseModel):
     custom_case: dict | None = None
     k: int | None = config.K_DEFAULT
     concurrency_search_config: ConcurrencySearchConfig = ConcurrencySearchConfig()
+    churn_search_config: ChurnSearchConfig = ChurnSearchConfig()
 
     '''
     @property

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -115,6 +115,7 @@ class TaskStage(StrEnum):
     LOAD = auto()
     SEARCH_SERIAL = auto()
     SEARCH_CONCURRENT = auto()
+    CHURN = auto()
 
     def __repr__(self) -> str:
         return str.__repr__(self.value)
@@ -126,6 +127,7 @@ ALL_TASK_STAGES = [
     TaskStage.LOAD,
     TaskStage.SEARCH_SERIAL,
     TaskStage.SEARCH_CONCURRENT,
+    TaskStage.CHURN
 ]
 
 


### PR DESCRIPTION
This PR introduces a new task stage that calculates recall under churn conditions, allowing us to evaluate the impact of deletions and reinsertions on recall over multiple cycles. The following changes have been made:

New Task Stage for Churn:

A new stage has been added to calculate recall after performing churn (deleting and reinserting embeddings) over multiple cycles. This helps evaluate how the recall changes as embeddings are churned.
New Parameters:

p_churn: Specifies the percentage of embeddings to churn (delete and reinsert) during each cycle.
cycles: Defines the number of churn cycles to perform, allowing multiple rounds of deletion and reinsertion to simulate data changes.

These updates provide the ability to benchmark vector database performance under churn conditions, ensuring better insights into recall degradation and recovery over time.