### PR TITLE
Add test case for testing recall under churn

### DIFF
--- a/vectordb_bench/__init__.py
+++ b/vectordb_bench/__init__.py
@@ -54,6 +54,9 @@ class config:
 
     OPTIMIZE_TIMEOUT_1536D_500K =  15 * 60   # 15min
     OPTIMIZE_TIMEOUT_1536D_5M   =   2.5 * 3600 # 2.5h
+
+    CHURN_CYCLES_DEFAULT = 0 # Keeping this default to 0 as most clients do not support churn
+    CHURN_P_CHURN_DEFAULT = 10
     def display(self) -> str:
         tmp = [
             i for i in inspect.getmembers(self)

--- a/vectordb_bench/backend/cases.py
+++ b/vectordb_bench/backend/cases.py
@@ -72,7 +72,7 @@ class CaseType(Enum):
 class CaseLabel(Enum):
     Load = auto()
     Performance = auto()
-
+    Churn = auto()
 
 class Case(BaseModel):
     """Undefined case
@@ -83,6 +83,8 @@ class Case(BaseModel):
         dataset(DataSet): dataset for this case runner.
         filter_rate(float | None): one of 99% | 1% | None
         filters(dict | None): filters for search
+        cycles(float | None): number of times to run churn cycles
+        p_churn(float | None): % of data to delete and reinsert
     """
 
     case_id: CaseType
@@ -95,6 +97,8 @@ class Case(BaseModel):
     optimize_timeout: float | int | None = None
 
     filter_rate: float | None = None
+    cycles: int | None = None
+    p_churn: float | int | None = None
 
     @property
     def filters(self) -> dict | None:

--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -187,6 +187,22 @@ class VectorDB(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs,
+    ) -> (int, Exception):
+        """Delete embeddings from the vector database based on metadata.
+        Args:
+            metadata (list[int]): List of metadata associated with the embeddings to delete.
+            **kwargs (Any): Vector database specific parameters.
+        Returns:
+            int: Number of deleted embeddings.
+            Exception: An exception if any error occurred during deletion.
+        """
+        raise NotImplementedError
+
     # TODO: remove
     @abstractmethod
     def optimize(self):

--- a/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import contextmanager
 import time
-from typing import Iterable, Type
+from typing import Any, Iterable, Optional, Tuple, Type
 from ..api import VectorDB, DBCaseConfig, DBConfig, IndexType
 from .config import AWSOpenSearchConfig, AWSOpenSearchIndexConfig, AWSOS_Engine
 from opensearchpy import OpenSearch
@@ -151,6 +151,13 @@ class AWSOpenSearch(VectorDB):
         except Exception as e:
             log.warning(f"Failed to search: {self.index_name} error: {str(e)}")
             raise e from None
+        
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def optimize(self):
         """optimize will be called between insertion and search in performance cases."""

--- a/vectordb_bench/backend/clients/chroma/chroma.py
+++ b/vectordb_bench/backend/clients/chroma/chroma.py
@@ -1,7 +1,7 @@
 import chromadb
 import logging 
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Optional, Tuple
 from ..api import VectorDB, DBCaseConfig
 
 log = logging.getLogger(__name__)
@@ -61,6 +61,13 @@ class ChromaClient(VectorDB):
         pass
 
     def optimize(self) -> None:
+        pass
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
         pass
 
     def insert_embeddings(

--- a/vectordb_bench/backend/clients/elastic_cloud/elastic_cloud.py
+++ b/vectordb_bench/backend/clients/elastic_cloud/elastic_cloud.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from contextlib import contextmanager
-from typing import Iterable
+from typing import Any, Iterable, Optional, Tuple
 from ..api import VectorDB
 from .config import ElasticCloudIndexConfig
 from elasticsearch.helpers import bulk
@@ -96,6 +96,13 @@ class ElasticCloud(VectorDB):
         except Exception as e:
             log.warning(f"Failed to insert data: {self.indice} error: {str(e)}")
             return (0, e)
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def search_embedding(
         self,

--- a/vectordb_bench/backend/clients/memorydb/memorydb.py
+++ b/vectordb_bench/backend/clients/memorydb/memorydb.py
@@ -194,6 +194,13 @@ class MemoryDB(VectorDB):
             return 0, e
         
         return result_len, None
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
     
     def _post_insert(self):
         """Wait for indexing to finish"""

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from contextlib import contextmanager
-from typing import Iterable
+from typing import Any, Iterable, Optional, Tuple
 
 from pymilvus import Collection, utility
 from pymilvus import CollectionSchema, DataType, FieldSchema, MilvusException
@@ -195,6 +195,14 @@ class Milvus(VectorDB):
             log.info(f"Failed to insert data: {e}")
             return (insert_count, e)
         return (insert_count, None)
+
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def search_embedding(
         self,

--- a/vectordb_bench/backend/clients/pgvecto_rs/pgvecto_rs.py
+++ b/vectordb_bench/backend/clients/pgvecto_rs/pgvecto_rs.py
@@ -265,6 +265,13 @@ class PgVectoRS(VectorDB):
             )
             return 0, e
 
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
+
     def search_embedding(
         self,
         query: list[float],

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -396,6 +396,38 @@ class PgVector(VectorDB):
             )
             return 0, e
 
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        """Deletes embeddings from the pgvector table based on metadata (IDs).
+        Args:
+            metadata (list[int]): List of metadata (IDs) for the embeddings to delete.
+            **kwargs (Any): Additional vector database-specific parameters.
+        Returns:
+            int: Number of deleted embeddings.
+            Exception: An exception if an error occurs.
+        """
+        assert self.conn is not None, "Connection is not initialized"
+        assert self.cursor is not None, "Cursor is not initialized"
+
+        try:
+            # Construct SQL for deleting embeddings based on the metadata (IDs)
+            delete_sql = sql.SQL(
+                "DELETE FROM public.{table_name} WHERE id = ANY(%s)"
+            ).format(table_name=sql.Identifier(self.table_name))
+
+            # Execute the delete statement
+            self.cursor.execute(delete_sql, (metadata,))
+            deleted_count = self.cursor.rowcount  # Get the number of rows deleted
+            self.conn.commit()
+
+            return deleted_count, None
+        except Exception as e:
+            log.warning(f"Failed to delete data from pgvector table ({self.table_name}), error: {e}")
+            return 0, e
+
     def search_embedding(
         self,
         query: list[float],

--- a/vectordb_bench/backend/clients/pgvectorscale/pgvectorscale.py
+++ b/vectordb_bench/backend/clients/pgvectorscale/pgvectorscale.py
@@ -266,6 +266,13 @@ class PgVectorScale(VectorDB):
             )
             return 0, e
 
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
+
     def search_embedding(
         self,
         query: list[float],

--- a/vectordb_bench/backend/clients/pinecone/pinecone.py
+++ b/vectordb_bench/backend/clients/pinecone/pinecone.py
@@ -2,7 +2,7 @@
 
 import logging
 from contextlib import contextmanager
-from typing import Type
+from typing import Any, Optional, Tuple, Type
 
 from ..api import VectorDB, DBConfig, DBCaseConfig, EmptyDBCaseConfig, IndexType
 from .config import PineconeConfig
@@ -94,6 +94,13 @@ class Pinecone(VectorDB):
         except Exception as e:
             return (insert_count, e)
         return (len(embeddings), None)
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def search_embedding(
         self,

--- a/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from contextlib import contextmanager
+from typing import Any, Optional, Tuple
 
 from ..api import VectorDB, DBCaseConfig
 from qdrant_client.http.models import (
@@ -126,6 +127,13 @@ class QdrantCloud(VectorDB):
             return 0, e
         else:
             return len(metadata), None
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def search_embedding(
         self,

--- a/vectordb_bench/backend/clients/redis/redis.py
+++ b/vectordb_bench/backend/clients/redis/redis.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import contextmanager
-from typing import Any, Type
+from typing import Any, Optional, Tuple, Type
 from ..api import VectorDB, DBConfig, DBCaseConfig, EmptyDBCaseConfig, IndexType
 from .config import RedisConfig
 import redis
@@ -123,6 +123,13 @@ class Redis(VectorDB):
             return 0, e
         
         return result_len, None
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
     
     def search_embedding(
         self,

--- a/vectordb_bench/backend/clients/weaviate_cloud/weaviate_cloud.py
+++ b/vectordb_bench/backend/clients/weaviate_cloud/weaviate_cloud.py
@@ -1,7 +1,7 @@
 """Wrapper around the Weaviate vector database over VectorDB"""
 
 import logging
-from typing import Iterable
+from typing import Any, Iterable, Optional, Tuple
 from contextlib import contextmanager
 
 import weaviate
@@ -112,6 +112,13 @@ class WeaviateCloud(VectorDB):
         except WeaviateBaseError as e:
             log.warning(f"Failed to insert data, error: {str(e)}")
             return (insert_count, e)
+
+    def delete_embeddings(
+        self,
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> Tuple[int, Optional[Exception]]:
+        pass
 
     def search_embedding(
         self,

--- a/vectordb_bench/metric.py
+++ b/vectordb_bench/metric.py
@@ -23,6 +23,7 @@ class Metric:
     conc_num_list: list[int] = field(default_factory=list)
     conc_qps_list: list[float] = field(default_factory=list)
     conc_latency_p99_list: list[float] = field(default_factory=list)
+    churn_results: list[dict] = field(default_factory=list)
 
 
 QURIES_PER_DOLLAR_METRIC = "QP$ (Quries per Dollar)"

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -80,6 +80,10 @@ class ConcurrencySearchConfig(BaseModel):
     num_concurrency: List[int] = config.NUM_CONCURRENCY
     concurrency_duration: int = config.CONCURRENCY_DURATION
 
+class ChurnSearchConfig(BaseModel):
+    p_churn: float = config.CHURN_P_CHURN_DEFAULT
+    cycles: int = config.CHURN_CYCLES_DEFAULT
+
 
 class CaseConfig(BaseModel):
     """cases, dataset, test cases, filter rate, params"""
@@ -88,6 +92,7 @@ class CaseConfig(BaseModel):
     custom_case: dict | None = None
     k: int | None = config.K_DEFAULT
     concurrency_search_config: ConcurrencySearchConfig = ConcurrencySearchConfig()
+    churn_search_config: ChurnSearchConfig = ChurnSearchConfig()
 
     '''
     @property
@@ -112,6 +117,7 @@ class TaskStage(StrEnum):
     LOAD = auto()
     SEARCH_SERIAL = auto()
     SEARCH_CONCURRENT = auto()
+    CHURN = auto()
 
     def __repr__(self) -> str:
         return str.__repr__(self.value)
@@ -123,6 +129,7 @@ ALL_TASK_STAGES = [
     TaskStage.LOAD,
     TaskStage.SEARCH_SERIAL,
     TaskStage.SEARCH_CONCURRENT,
+    TaskStage.CHURN
 ]
 
 


### PR DESCRIPTION
This PR introduces a new task stage that calculates recall under churn conditions, allowing us to evaluate the impact of deletions and reinsertions on recall over multiple cycles. The following changes have been made:

New Task Stage for Churn:

A new stage has been added to calculate recall after performing churn (deleting and reinserting embeddings) over multiple cycles. This helps evaluate how the recall changes as embeddings are churned.
New Parameters:

p_churn: Specifies the percentage of embeddings to churn (delete and reinsert) during each cycle.
cycles: Defines the number of churn cycles to perform, allowing multiple rounds of deletion and reinsertion to simulate data changes.

These updates provide the ability to benchmark vector database performance under churn conditions, ensuring better insights into recall degradation and recovery over time.