### PR TITLE
Add label filtering support to pgdiskann client

### DIFF
--- a/benchmark_run_utils/utils.py
+++ b/benchmark_run_utils/utils.py
@@ -255,7 +255,7 @@ def get_base_command(case: dict, db_config: dict) -> list:
         base_command.append("--skip-search-concurrent")
     
     if "reranking" in case:
-        if case.get("reranking", True):
+        if case.get("reranking", False):
             base_command.append("--reranking")
         else:
             base_command.append("--skip-reranking")

--- a/benchmark_run_utils/utils.py
+++ b/benchmark_run_utils/utils.py
@@ -260,8 +260,15 @@ def get_base_command(case: dict, db_config: dict) -> list:
         else:
             base_command.append("--skip-reranking")
     
-    for key, value in case["index-params"].items():
-        base_command.extend([f"--{key}", str(value)])
+    for key, value in case.get("index-params", {}).items():
+        if key == "product-quantization":
+            if value is True or str(value).lower() == "true":
+                base_command.append("--product-quantization")
+            else:
+                base_command.append("--no-product-quantization")
+        else:
+            # Regular parameters
+            base_command.extend([f"--{key}", str(value)])
 
     return base_command
 

--- a/vectordb_bench/backend/clients/pgdiskann/cli.py
+++ b/vectordb_bench/backend/clients/pgdiskann/cli.py
@@ -66,6 +66,16 @@ class PgDiskAnnTypedDict(CommonTypedDict):
             help="PgDiskAnn l_value_is",
         ),
     ]
+    product_quantization: Annotated[
+        bool,
+        click.option(
+            "--product-quantization/--no-product-quantization",
+            type=bool,
+            help="Enable product quantization for index compression",
+            default=True,
+            show_default=True,
+        ),
+    ]
     reranking: Annotated[
         bool | None,
         click.option(
@@ -141,6 +151,7 @@ def PgDiskAnn(
             l_value_ib=parameters["l_value_ib"],
             pq_param_num_chunks=parameters["pq_param_num_chunks"],
             l_value_is=parameters["l_value_is"],
+            product_quantization=parameters["product_quantization"], 
             reranking=parameters["reranking"],
             reranking_metric=parameters["reranking_metric"],
             quantized_fetch_limit=parameters["quantized_fetch_limit"],

--- a/vectordb_bench/backend/clients/pgdiskann/config.py
+++ b/vectordb_bench/backend/clients/pgdiskann/config.py
@@ -124,6 +124,7 @@ class PgDiskANNImplConfig(PgDiskANNIndexConfig):
     l_value_ib: int | None
     pq_param_num_chunks: int | None
     l_value_is: float | None
+    product_quantization: bool = True
     reranking: bool | None = None
     reranking_metric: str | None = None
     quantized_fetch_limit: int | None = None
@@ -138,7 +139,7 @@ class PgDiskANNImplConfig(PgDiskANNIndexConfig):
                 "max_neighbors": self.max_neighbors,
                 "l_value_ib": self.l_value_ib,
                 "pq_param_num_chunks": self.pq_param_num_chunks,
-                "product_quantized": str(self.reranking),
+                "product_quantized": str(self.product_quantization),
             },
             "maintenance_work_mem": self.maintenance_work_mem,
             "max_parallel_workers": self.max_parallel_workers,
@@ -148,6 +149,7 @@ class PgDiskANNImplConfig(PgDiskANNIndexConfig):
         return {
             "metric": self.parse_metric(),
             "metric_fun_op": self.parse_metric_fun_op(),
+            "product_quantization": self.product_quantization, 
             "reranking": self.reranking,
             "reranking_metric_fun_op": self.parse_reranking_metric_fun_op(),
             "quantized_fetch_limit": self.quantized_fetch_limit,

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -10,6 +10,7 @@ import psycopg
 from pgvector.psycopg import register_vector
 from psycopg import Connection, Cursor, sql
 
+from vectordb_bench.backend.filter import Filter, FilterOp
 from ..api import VectorDB
 from .config import PgDiskANNConfigDict, PgDiskANNIndexConfig
 
@@ -19,8 +20,14 @@ log = logging.getLogger(__name__)
 class PgDiskANN(VectorDB):
     """Use psycopg instructions"""
 
+    supported_filter_types: list[FilterOp] = [
+            FilterOp.NonFilter,
+            FilterOp.NumGE,
+            FilterOp.StrEqual,  
+    ]
+
     conn: psycopg.Connection[Any] | None = None
-    coursor: psycopg.Cursor[Any] | None = None
+    cursor: psycopg.Cursor[Any] | None = None
 
     _filtered_search: sql.Composed
     _unfiltered_search: sql.Composed
@@ -32,6 +39,7 @@ class PgDiskANN(VectorDB):
         db_case_config: PgDiskANNIndexConfig,
         collection_name: str = "pg_diskann_collection",
         drop_old: bool = False,
+        with_scalar_labels: bool = False,
         **kwargs,
     ):
         self.name = "PgDiskANN"
@@ -39,6 +47,10 @@ class PgDiskANN(VectorDB):
         self.case_config = db_case_config
         self.table_name = collection_name
         self.dim = dim
+        self.with_scalar_labels = with_scalar_labels
+        self._scalar_label_field = "label"
+        self.filter_op = None
+        self.filter_value = None
 
         self._index_name = "pgdiskann_index"
         self._primary_field = "id"
@@ -334,11 +346,23 @@ class PgDiskANN(VectorDB):
         try:
             log.info(f"{self.name} client create table : {self.table_name}")
 
-            self.cursor.execute(
-                sql.SQL(
-                    "CREATE TABLE IF NOT EXISTS public.{table_name} (id BIGINT PRIMARY KEY, embedding vector({dim}));",
-                ).format(table_name=sql.Identifier(self.table_name), dim=dim),
-            )
+            if self.with_scalar_labels:
+                # Create table WITH label column
+                self.cursor.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS public.{table_name} 
+                        (id BIGINT PRIMARY KEY, embedding vector({dim}), label VARCHAR(64));
+                        """,
+                    ).format(table_name=sql.Identifier(self.table_name), dim=dim),
+                )
+            else:
+                # Create table WITHOUT label column (existing behavior)
+                self.cursor.execute(
+                    sql.SQL(
+                        "CREATE TABLE IF NOT EXISTS public.{table_name} (id BIGINT PRIMARY KEY, embedding vector({dim}));",
+                    ).format(table_name=sql.Identifier(self.table_name), dim=dim),
+                )
             self.conn.commit()
         except Exception as e:
             log.warning(f"Failed to create pgdiskann table: {self.table_name} error: {e}")
@@ -348,10 +372,14 @@ class PgDiskANN(VectorDB):
         self,
         embeddings: list[list[float]],
         metadata: list[int],
+        labels_data: list[str] | None = None, 
         **kwargs: Any,
     ) -> tuple[int, Exception | None]:
         assert self.conn is not None, "Connection is not initialized"
         assert self.cursor is not None, "Cursor is not initialized"
+
+        if self.with_scalar_labels:
+            assert labels_data is not None, "labels_data should be provided if with_scalar_labels is set to True"
 
         try:
             metadata_arr = np.array(metadata)
@@ -362,9 +390,14 @@ class PgDiskANN(VectorDB):
                     table_name=sql.Identifier(self.table_name),
                 ),
             ) as copy:
-                copy.set_types(["bigint", "vector"])
-                for i, row in enumerate(metadata_arr):
-                    copy.write_row((row, embeddings_arr[i]))
+                if self.with_scalar_labels:
+                    copy.set_types(["bigint", "vector", "varchar"])
+                    for i, row in enumerate(metadata_arr):
+                        copy.write_row((row, embeddings_arr[i], labels_data[i]))
+                else:
+                    copy.set_types(["bigint", "vector"])
+                    for i, row in enumerate(metadata_arr):
+                        copy.write_row((row, embeddings_arr[i]))
             self.conn.commit()
 
             if kwargs.get("last_batch"):
@@ -375,49 +408,123 @@ class PgDiskANN(VectorDB):
             log.warning(f"Failed to insert data into table ({self.table_name}), error: {e}")
             return 0, e
 
+    def prepare_filter(self, filters: Filter):
+        """Prepare filter for label or integer-based filtering"""
+        from vectordb_bench.backend.filter import FilterOp
+        
+        if filters.type == FilterOp.NonFilter:
+            self.filter_op = FilterOp.NonFilter
+            self.filter_value = None
+            
+        elif filters.type == FilterOp.NumGE:
+            # Integer filtering: WHERE id >= X
+            self.filter_op = FilterOp.NumGE
+            self.filter_value = filters.int_value
+            
+        elif filters.type == FilterOp.StrEqual:
+            # Label filtering: WHERE label = 'label_1p'
+            self.filter_op = FilterOp.StrEqual
+            self.filter_value = filters.label_value
+        else:
+            msg = f"Not support Filter for PgDiskANN - {filters}"
+            raise ValueError(msg)
+
+
     def search_embedding(
         self,
         query: list[float],
         k: int = 100,
-        filters: dict | None = None,
+        filters: dict | None = None,  
         timeout: int | None = None,
     ) -> list[int]:
         assert self.conn is not None, "Connection is not initialized"
         assert self.cursor is not None, "Cursor is not initialized"
 
+        from vectordb_bench.backend.filter import FilterOp
+        
         search_params = self.case_config.search_param()
         is_reranking = search_params.get("reranking", False)
-
+        
         q = np.asarray(query)
-        if filters:
-            gt = filters.get("id")
+        
+        # Build the appropriate query based on filter_op
+        if self.filter_op == FilterOp.StrEqual:
+            # Label filtering: e.g. WHERE label = 'label_1p'
+            if is_reranking:
+                query_sql = sql.SQL("""
+                    SELECT i.id
+                    FROM (
+                        SELECT id, embedding
+                        FROM public.{table_name}
+                        WHERE {label_field} = %s
+                        ORDER BY embedding {metric_fun_op} %s::vector
+                        LIMIT {quantized_fetch_limit}::int
+                    ) i
+                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
+                    LIMIT %s::int
+                """).format(
+                    table_name=sql.Identifier(self.table_name),
+                    label_field=sql.Identifier(self._scalar_label_field),
+                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
+                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
+                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
+                )
+                result = self.cursor.execute(
+                    query_sql,
+                    (self.filter_value, q, q, k),
+                    prepare=True,
+                    binary=True,
+                )
+            else:
+                query_sql = sql.Composed([
+                    sql.SQL(
+                        "SELECT id FROM public.{table_name} WHERE {label_field} = %s ORDER BY embedding ",
+                    ).format(
+                        table_name=sql.Identifier(self.table_name),
+                        label_field=sql.Identifier(self._scalar_label_field),
+                    ),
+                    sql.SQL(search_params["metric_fun_op"]),
+                    sql.SQL(" %s::vector LIMIT %s::int"),
+                ])
+                result = self.cursor.execute(
+                    query_sql,
+                    (self.filter_value, q, k),
+                    prepare=True,
+                    binary=True,
+                )
+                
+        elif self.filter_op == FilterOp.NumGE:
+            # Integer filtering: WHERE id >= X (existing behavior)
             if is_reranking:
                 result = self.cursor.execute(
                     self._filtered_search,
-                    (gt, q, q, k),
+                    (self.filter_value, q, q, k),
                     prepare=True,
                     binary=True,
                 )
             else:
                 result = self.cursor.execute(
                     self._filtered_search,
-                    (gt, q, k),
+                    (self.filter_value, q, k),
                     prepare=True,
                     binary=True,
                 )
-        elif is_reranking:
-            result = self.cursor.execute(
-                self._unfiltered_search,
-                (q, q, k),
-                prepare=True,
-                binary=True,
-            )
+                
         else:
-            result = self.cursor.execute(
-                self._unfiltered_search,
-                (q, k),
-                prepare=True,
-                binary=True,
-            )
+            # No filtering (existing behavior)
+            if is_reranking:
+                result = self.cursor.execute(
+                    self._unfiltered_search,
+                    (q, q, k),
+                    prepare=True,
+                    binary=True,
+                )
+            else:
+                result = self.cursor.execute(
+                    self._unfiltered_search,
+                    (q, k),
+                    prepare=True,
+                    binary=True,
+                )
 
         return [int(i[0]) for i in result.fetchall()]

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -21,16 +21,15 @@ class PgDiskANN(VectorDB):
     """Use psycopg instructions"""
 
     supported_filter_types: list[FilterOp] = [
-            FilterOp.NonFilter,
-            FilterOp.NumGE,
-            FilterOp.StrEqual,  
+        FilterOp.NonFilter,
+        FilterOp.NumGE,
+        FilterOp.StrEqual,
     ]
 
     conn: psycopg.Connection[Any] | None = None
     cursor: psycopg.Cursor[Any] | None = None
 
-    _filtered_search: sql.Composed
-    _unfiltered_search: sql.Composed
+    _search: sql.Composed  
 
     def __init__(
         self,
@@ -49,8 +48,7 @@ class PgDiskANN(VectorDB):
         self.dim = dim
         self.with_scalar_labels = with_scalar_labels
         self._scalar_label_field = "label"
-        self.filter_op = None
-        self.filter_value = None
+        self.where_clause = "" 
 
         self._index_name = "pgdiskann_index"
         self._primary_field = "id"
@@ -90,18 +88,19 @@ class PgDiskANN(VectorDB):
             assert self.cursor is not None, "Cursor is not initialized"
             log.info(f"{self.name} client get size info.")
 
-            size_sql = sql.SQL("SELECT pg_size_pretty(pg_table_size('{table_name}')) as table_size, pg_size_pretty(pg_table_size('{index_name}')) as index_size;").format(
+            size_sql = sql.SQL(
+                "SELECT pg_size_pretty(pg_table_size('{table_name}')) as table_size, pg_size_pretty(pg_table_size('{index_name}')) as index_size;"
+            ).format(
                 table_name=sql.Identifier(self.table_name),
-                index_name=sql.Identifier(self._index_name)
+                index_name=sql.Identifier(self._index_name),
             )
             log.debug(size_sql.as_string(self.cursor))
             self.cursor.execute(size_sql)
             self.conn.commit()
             result = self.cursor.fetchone()
 
-            # Parse the results
             if result:
-                table_size = result[0]  # First column value
+                table_size = result[0]
                 index_size = result[1]
                 log.info(f"Table Size: {table_size}, Index Size: {index_size}")
                 return (table_size, index_size)
@@ -109,9 +108,7 @@ class PgDiskANN(VectorDB):
                 log.error("No results returned from the query.")
                 return (0, 0)
         except Exception as e:
-            log.warning(
-                f"Failed to fetch table and index information"
-            )
+            log.warning("Failed to fetch table and index information")
             return (0, 0)
 
     @staticmethod
@@ -128,6 +125,49 @@ class PgDiskANN(VectorDB):
 
         return conn, cursor
 
+    def _generate_search_query(self) -> sql.Composed:
+        """Generate search query with where_clause placeholder"""
+        search_params = self.case_config.search_param()
+
+        if search_params.get("reranking"):
+            # Reranking-enabled query
+            search_query = sql.SQL(
+                """
+                SELECT i.id
+                FROM (
+                    SELECT id, embedding
+                    FROM public.{table_name}
+                    {where_clause}
+                    ORDER BY embedding {metric_fun_op} %s::vector
+                    LIMIT {quantized_fetch_limit}::int
+                ) i
+                ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
+                LIMIT %s::int
+                """
+            ).format(
+                table_name=sql.Identifier(self.table_name),
+                where_clause=sql.SQL(self.where_clause),
+                metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
+                reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
+                quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
+            )
+        else:
+            # Standard query
+            search_query = sql.Composed(
+                [
+                    sql.SQL(
+                        "SELECT id FROM public.{table_name} {where_clause} ORDER BY embedding "
+                    ).format(
+                        table_name=sql.Identifier(self.table_name),
+                        where_clause=sql.SQL(self.where_clause),
+                    ),
+                    sql.SQL(search_params["metric_fun_op"]),
+                    sql.SQL(" %s::vector LIMIT %s::int"),
+                ]
+            )
+
+        return search_query
+
     @contextmanager
     def init(self) -> Generator[None, None, None]:
         self.conn, self.cursor = self._create_connection(**self.db_config)
@@ -137,74 +177,12 @@ class PgDiskANN(VectorDB):
         if len(session_options) > 0:
             for setting_name, setting_val in session_options.items():
                 command = sql.SQL("SET {setting_name} = {setting_val};").format(
-                    setting_name=sql.Identifier(setting_name), setting_val=sql.Literal(setting_val)
+                    setting_name=sql.Identifier(setting_name),
+                    setting_val=sql.Literal(setting_val),
                 )
                 log.debug(command.as_string(self.cursor))
                 self.cursor.execute(command)
             self.conn.commit()
-
-        search_params = self.case_config.search_param()
-
-        if search_params.get("reranking"):
-            # Reranking-enabled queries
-            self._filtered_search = sql.SQL("""
-                SELECT i.id
-                FROM (
-                    SELECT id, embedding
-                    FROM public.{table_name}
-                    WHERE id >= %s
-                    ORDER BY embedding {metric_fun_op} %s::vector
-                    LIMIT {quantized_fetch_limit}::int
-                ) i
-                ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                LIMIT %s::int
-            """).format(
-                table_name=sql.Identifier(self.table_name),
-                metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-            )
-
-            self._unfiltered_search = sql.SQL("""
-                SELECT i.id
-                FROM (
-                    SELECT id, embedding
-                    FROM public.{table_name}
-                    ORDER BY embedding {metric_fun_op} %s::vector
-                    LIMIT {quantized_fetch_limit}::int
-                ) i
-                ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                LIMIT %s::int
-            """).format(
-                table_name=sql.Identifier(self.table_name),
-                metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-            )
-
-        else:
-            self._filtered_search = sql.Composed(
-                [
-                    sql.SQL(
-                        "SELECT id FROM public.{table_name} WHERE id >= %s ORDER BY embedding ",
-                    ).format(table_name=sql.Identifier(self.table_name)),
-                    sql.SQL(search_params["metric_fun_op"]),
-                    sql.SQL(" %s::vector LIMIT %s::int"),
-                ]
-            )
-
-            self._unfiltered_search = sql.Composed(
-                [
-                    sql.SQL("SELECT id FROM public.{table_name} ORDER BY embedding ").format(
-                        table_name=sql.Identifier(self.table_name)
-                    ),
-                    sql.SQL(search_params["metric_fun_op"]),
-                    sql.SQL(" %s::vector LIMIT %s::int"),
-                ]
-            )
-
-        log.debug(f"Unfiltered search query={self._unfiltered_search.as_string(self.conn)}")
-        log.debug(f"Filtered search query={self._filtered_search.as_string(self.conn)}")
 
         try:
             yield
@@ -321,13 +299,17 @@ class PgDiskANN(VectorDB):
                     ),
                 )
 
-        with_clause = sql.SQL("WITH ({});").format(sql.SQL(", ").join(options)) if any(options) else sql.Composed(())
+        with_clause = (
+            sql.SQL("WITH ({});").format(sql.SQL(", ").join(options))
+            if any(options)
+            else sql.Composed(())
+        )
 
         index_create_sql = sql.SQL(
             """
             CREATE INDEX IF NOT EXISTS {index_name} ON public.{table_name}
             USING {index_type} (embedding {embedding_metric})
-            """,
+            """
         ).format(
             index_name=sql.Identifier(self._index_name),
             table_name=sql.Identifier(self.table_name),
@@ -352,17 +334,37 @@ class PgDiskANN(VectorDB):
                     sql.SQL(
                         """
                         CREATE TABLE IF NOT EXISTS public.{table_name} 
-                        (id BIGINT PRIMARY KEY, embedding vector({dim}), label VARCHAR(64));
-                        """,
-                    ).format(table_name=sql.Identifier(self.table_name), dim=dim),
+                        ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}), {label_field} VARCHAR(64));
+                        """
+                    ).format(
+                        table_name=sql.Identifier(self.table_name),
+                        dim=dim,
+                        primary_field=sql.Identifier(self._primary_field),
+                        label_field=sql.Identifier(self._scalar_label_field),
+                    ),
                 )
             else:
-                # Create table WITHOUT label column (existing behavior)
+                # Create table WITHOUT label column
                 self.cursor.execute(
                     sql.SQL(
-                        "CREATE TABLE IF NOT EXISTS public.{table_name} (id BIGINT PRIMARY KEY, embedding vector({dim}));",
-                    ).format(table_name=sql.Identifier(self.table_name), dim=dim),
+                        """
+                        CREATE TABLE IF NOT EXISTS public.{table_name} 
+                        ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}));
+                        """
+                    ).format(
+                        table_name=sql.Identifier(self.table_name),
+                        dim=dim,
+                        primary_field=sql.Identifier(self._primary_field),
+                    ),
                 )
+
+            # Prevent TOAST compression on vector column for better performance
+            self.cursor.execute(
+                sql.SQL(
+                    "ALTER TABLE public.{table_name} ALTER COLUMN embedding SET STORAGE PLAIN;"
+                ).format(table_name=sql.Identifier(self.table_name)),
+            )
+            
             self.conn.commit()
         except Exception as e:
             log.warning(f"Failed to create pgdiskann table: {self.table_name} error: {e}")
@@ -372,14 +374,16 @@ class PgDiskANN(VectorDB):
         self,
         embeddings: list[list[float]],
         metadata: list[int],
-        labels_data: list[str] | None = None, 
+        labels_data: list[str] | None = None,
         **kwargs: Any,
     ) -> tuple[int, Exception | None]:
         assert self.conn is not None, "Connection is not initialized"
         assert self.cursor is not None, "Cursor is not initialized"
 
         if self.with_scalar_labels:
-            assert labels_data is not None, "labels_data should be provided if with_scalar_labels is set to True"
+            assert (
+                labels_data is not None
+            ), "labels_data should be provided if with_scalar_labels is set to True"
 
         try:
             metadata_arr = np.array(metadata)
@@ -409,122 +413,40 @@ class PgDiskANN(VectorDB):
             return 0, e
 
     def prepare_filter(self, filters: Filter):
-        """Prepare filter for label or integer-based filtering"""
-        from vectordb_bench.backend.filter import FilterOp
-        
+        """Prepare filter - builds where_clause"""
         if filters.type == FilterOp.NonFilter:
-            self.filter_op = FilterOp.NonFilter
-            self.filter_value = None
-            
+            self.where_clause = ""
         elif filters.type == FilterOp.NumGE:
-            # Integer filtering: WHERE id >= X
-            self.filter_op = FilterOp.NumGE
-            self.filter_value = filters.int_value
-            
+            self.where_clause = f"WHERE {self._primary_field} >= {filters.int_value}"
         elif filters.type == FilterOp.StrEqual:
-            # Label filtering: WHERE label = 'label_1p'
-            self.filter_op = FilterOp.StrEqual
-            self.filter_value = filters.label_value
+            self.where_clause = f"WHERE {self._scalar_label_field} = '{filters.label_value}'"
         else:
             msg = f"Not support Filter for PgDiskANN - {filters}"
             raise ValueError(msg)
 
+        # Generate query with embedded where_clause
+        self._search = self._generate_search_query()
+        log.debug(f"Search query={self._search.as_string(self.conn)}")
 
     def search_embedding(
         self,
         query: list[float],
         k: int = 100,
-        filters: dict | None = None,  
         timeout: int | None = None,
+        **kwargs: Any,
     ) -> list[int]:
         assert self.conn is not None, "Connection is not initialized"
         assert self.cursor is not None, "Cursor is not initialized"
 
-        from vectordb_bench.backend.filter import FilterOp
-        
         search_params = self.case_config.search_param()
-        is_reranking = search_params.get("reranking", False)
-        
         q = np.asarray(query)
         
-        # Build the appropriate query based on filter_op
-        if self.filter_op == FilterOp.StrEqual:
-            # Label filtering: e.g. WHERE label = 'label_1p'
-            if is_reranking:
-                query_sql = sql.SQL("""
-                    SELECT i.id
-                    FROM (
-                        SELECT id, embedding
-                        FROM public.{table_name}
-                        WHERE {label_field} = %s
-                        ORDER BY embedding {metric_fun_op} %s::vector
-                        LIMIT {quantized_fetch_limit}::int
-                    ) i
-                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                    LIMIT %s::int
-                """).format(
-                    table_name=sql.Identifier(self.table_name),
-                    label_field=sql.Identifier(self._scalar_label_field),
-                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-                )
-                result = self.cursor.execute(
-                    query_sql,
-                    (self.filter_value, q, q, k),
-                    prepare=True,
-                    binary=True,
-                )
-            else:
-                query_sql = sql.Composed([
-                    sql.SQL(
-                        "SELECT id FROM public.{table_name} WHERE {label_field} = %s ORDER BY embedding ",
-                    ).format(
-                        table_name=sql.Identifier(self.table_name),
-                        label_field=sql.Identifier(self._scalar_label_field),
-                    ),
-                    sql.SQL(search_params["metric_fun_op"]),
-                    sql.SQL(" %s::vector LIMIT %s::int"),
-                ])
-                result = self.cursor.execute(
-                    query_sql,
-                    (self.filter_value, q, k),
-                    prepare=True,
-                    binary=True,
-                )
-                
-        elif self.filter_op == FilterOp.NumGE:
-            # Integer filtering: WHERE id >= X (existing behavior)
-            if is_reranking:
-                result = self.cursor.execute(
-                    self._filtered_search,
-                    (self.filter_value, q, q, k),
-                    prepare=True,
-                    binary=True,
-                )
-            else:
-                result = self.cursor.execute(
-                    self._filtered_search,
-                    (self.filter_value, q, k),
-                    prepare=True,
-                    binary=True,
-                )
-                
-        else:
-            # No filtering (existing behavior)
-            if is_reranking:
-                result = self.cursor.execute(
-                    self._unfiltered_search,
-                    (q, q, k),
-                    prepare=True,
-                    binary=True,
-                )
-            else:
-                result = self.cursor.execute(
-                    self._unfiltered_search,
-                    (q, k),
-                    prepare=True,
-                    binary=True,
-                )
-
+        result = self.cursor.execute(
+            self._search,
+            (q, q, k) if search_params.get("reranking", False) else (q, k),
+            prepare=True,
+            binary=True,
+        )
+        
         return [int(i[0]) for i in result.fetchall()]
+

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -130,87 +130,44 @@ class PgDiskANN(VectorDB):
         search_params = self.case_config.search_param()
         product_quantization = search_params.get("product_quantization", True)
         reranking = search_params.get("reranking", False)
-        
-        if product_quantization:
-            # Product quantization enabled
-            if reranking:
-                # PQ + Reranking
-                search_query = sql.SQL(
-                    """
-                    SELECT i.id
-                    FROM (
-                        SELECT id, embedding
-                        FROM public.{table_name}
-                        {where_clause}
-                        ORDER BY embedding {metric_fun_op} %s::vector
-                        LIMIT {quantized_fetch_limit}::int
-                    ) i
-                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                    LIMIT %s::int
-                    """
-                ).format(
-                    table_name=sql.Identifier(self.table_name),
-                    where_clause=sql.SQL(self.where_clause),
-                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-                )
-            else:
-                # PQ only
-                search_query = sql.Composed(
-                    [
-                        sql.SQL(
-                            "SELECT {primary_field} FROM public.{table_name} {where_clause} ORDER BY {vector_field}"
-                        ).format(
-                            table_name=sql.Identifier(self.table_name),
-                            primary_field=sql.Identifier(self._primary_field),
-                            vector_field=sql.Identifier(self._vector_field),
-                            where_clause=sql.SQL(self.where_clause),
-                        ),
-                        sql.SQL(search_params["metric_fun_op"]),
-                        sql.SQL(" %s::vector LIMIT %s::int"),
-                    ]
-                )
+
+        if product_quantization and reranking:
+            search_query = sql.SQL(
+                """
+                SELECT i.id
+                FROM (
+                    SELECT id, embedding
+                    FROM public.{table_name}
+                    {where_clause}
+                    ORDER BY embedding {metric_fun_op} %s::vector
+                    LIMIT {quantized_fetch_limit}::int
+                ) i
+                ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
+                LIMIT %s::int
+                """
+            ).format(
+                table_name=sql.Identifier(self.table_name),
+                where_clause=sql.SQL(self.where_clause),
+                metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
+                reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
+                quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
+            )
+
         else:
-            # Product quantization disabled
-            if reranking:
-                # Reranking only
-                search_query = sql.SQL(
-                    """
-                    SELECT i.id
-                    FROM (
-                        SELECT id, embedding
-                        FROM public.{table_name}
-                        {where_clause}
-                        ORDER BY embedding {metric_fun_op} %s::vector
-                        LIMIT {quantized_fetch_limit}::int
-                    ) i
-                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                    LIMIT %s::int
-                    """
-                ).format(
-                    table_name=sql.Identifier(self.table_name),
-                    where_clause=sql.SQL(self.where_clause),
-                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-                )
-            else:
-                # Standard query
-                search_query = sql.Composed(
-                    [
-                        sql.SQL(
-                            "SELECT {primary_field} FROM public.{table_name} {where_clause} ORDER BY {vector_field}"
-                        ).format(
-                            table_name=sql.Identifier(self.table_name),
-                            primary_field=sql.Identifier(self._primary_field),
-                            vector_field=sql.Identifier(self._vector_field),
-                            where_clause=sql.SQL(self.where_clause),
-                        ),
-                        sql.SQL(search_params["metric_fun_op"]),
-                        sql.SQL(" %s::vector LIMIT %s::int"),
-                    ]
-                )
+            search_query = sql.Composed(
+                [
+                    sql.SQL(
+                        "SELECT {primary_field} FROM public.{table_name} {where_clause} ORDER BY {vector_field}"
+                    ).format(
+                        table_name=sql.Identifier(self.table_name),
+                        primary_field=sql.Identifier(self._primary_field),
+                        vector_field=sql.Identifier(self._vector_field),
+                        where_clause=sql.SQL(self.where_clause),
+                    ),
+                    sql.SQL(search_params["metric_fun_op"]),
+                    sql.SQL(" %s::vector LIMIT %s::int"),
+                ]
+            )
 
         return search_query
 

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -126,45 +126,91 @@ class PgDiskANN(VectorDB):
         return conn, cursor
 
     def _generate_search_query(self) -> sql.Composed:
-        """Generate search query with where_clause placeholder"""
-        search_params = self.case_config.search_param()
 
-        if search_params.get("reranking"):
-            # Reranking-enabled query
-            search_query = sql.SQL(
-                """
-                SELECT i.id
-                FROM (
-                    SELECT id, embedding
-                    FROM public.{table_name}
-                    {where_clause}
-                    ORDER BY embedding {metric_fun_op} %s::vector
-                    LIMIT {quantized_fetch_limit}::int
-                ) i
-                ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
-                LIMIT %s::int
-                """
-            ).format(
-                table_name=sql.Identifier(self.table_name),
-                where_clause=sql.SQL(self.where_clause),
-                metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
-                reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
-                quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
-            )
+        search_params = self.case_config.search_param()
+        product_quantization = search_params.get("product_quantization", True)
+        reranking = search_params.get("reranking", False)
+        
+        if product_quantization:
+            # Product quantization enabled
+            if reranking:
+                # PQ + Reranking
+                search_query = sql.SQL(
+                    """
+                    SELECT i.id
+                    FROM (
+                        SELECT id, embedding
+                        FROM public.{table_name}
+                        {where_clause}
+                        ORDER BY embedding {metric_fun_op} %s::vector
+                        LIMIT {quantized_fetch_limit}::int
+                    ) i
+                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
+                    LIMIT %s::int
+                    """
+                ).format(
+                    table_name=sql.Identifier(self.table_name),
+                    where_clause=sql.SQL(self.where_clause),
+                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
+                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
+                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
+                )
+            else:
+                # PQ only
+                search_query = sql.Composed(
+                    [
+                        sql.SQL(
+                            "SELECT {primary_field} FROM public.{table_name} {where_clause} ORDER BY {vector_field}"
+                        ).format(
+                            table_name=sql.Identifier(self.table_name),
+                            primary_field=sql.Identifier(self._primary_field),
+                            vector_field=sql.Identifier(self._vector_field),
+                            where_clause=sql.SQL(self.where_clause),
+                        ),
+                        sql.SQL(search_params["metric_fun_op"]),
+                        sql.SQL(" %s::vector LIMIT %s::int"),
+                    ]
+                )
         else:
-            # Standard query
-            search_query = sql.Composed(
-                [
-                    sql.SQL(
-                        "SELECT id FROM public.{table_name} {where_clause} ORDER BY embedding "
-                    ).format(
-                        table_name=sql.Identifier(self.table_name),
-                        where_clause=sql.SQL(self.where_clause),
-                    ),
-                    sql.SQL(search_params["metric_fun_op"]),
-                    sql.SQL(" %s::vector LIMIT %s::int"),
-                ]
-            )
+            # Product quantization disabled
+            if reranking:
+                # Reranking only
+                search_query = sql.SQL(
+                    """
+                    SELECT i.id
+                    FROM (
+                        SELECT id, embedding
+                        FROM public.{table_name}
+                        {where_clause}
+                        ORDER BY embedding {metric_fun_op} %s::vector
+                        LIMIT {quantized_fetch_limit}::int
+                    ) i
+                    ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
+                    LIMIT %s::int
+                    """
+                ).format(
+                    table_name=sql.Identifier(self.table_name),
+                    where_clause=sql.SQL(self.where_clause),
+                    metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
+                    reranking_metric_fun_op=sql.SQL(search_params["reranking_metric_fun_op"]),
+                    quantized_fetch_limit=sql.Literal(search_params["quantized_fetch_limit"]),
+                )
+            else:
+                # Standard query
+                search_query = sql.Composed(
+                    [
+                        sql.SQL(
+                            "SELECT {primary_field} FROM public.{table_name} {where_clause} ORDER BY {vector_field}"
+                        ).format(
+                            table_name=sql.Identifier(self.table_name),
+                            primary_field=sql.Identifier(self._primary_field),
+                            vector_field=sql.Identifier(self._vector_field),
+                            where_clause=sql.SQL(self.where_clause),
+                        ),
+                        sql.SQL(search_params["metric_fun_op"]),
+                        sql.SQL(" %s::vector LIMIT %s::int"),
+                    ]
+                )
 
         return search_query
 
@@ -288,6 +334,9 @@ class PgDiskANN(VectorDB):
 
         index_param: dict[str, Any] = self.case_config.index_param()
         self._set_parallel_index_build_param()
+
+        product_quantized = index_param["options"].get("product_quantized", "True")
+        log.info(f"{self.name} index creation with product_quantization={product_quantized}")
 
         options = []
         for option_name, option_val in index_param["options"].items():
@@ -413,7 +462,6 @@ class PgDiskANN(VectorDB):
             return 0, e
 
     def prepare_filter(self, filters: Filter):
-        """Prepare filter - builds where_clause"""
         if filters.type == FilterOp.NonFilter:
             self.where_clause = ""
         elif filters.type == FilterOp.NumGE:
@@ -424,7 +472,7 @@ class PgDiskANN(VectorDB):
             msg = f"Not support Filter for PgDiskANN - {filters}"
             raise ValueError(msg)
 
-        # Generate query with embedded where_clause
+        # Generate query 
         self._search = self._generate_search_query()
         log.debug(f"Search query={self._search.as_string(self.conn)}")
 
@@ -435,15 +483,16 @@ class PgDiskANN(VectorDB):
         timeout: int | None = None,
         **kwargs: Any,
     ) -> list[int]:
+
         assert self.conn is not None, "Connection is not initialized"
         assert self.cursor is not None, "Cursor is not initialized"
 
-        search_params = self.case_config.search_param()
+        search_param = self.case_config.search_param()
         q = np.asarray(query)
         
         result = self.cursor.execute(
             self._search,
-            (q, q, k) if search_params.get("reranking", False) else (q, k),
+            (q, q, k) if search_param["reranking"] else (q, k),
             prepare=True,
             binary=True,
         )

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -474,12 +474,21 @@ CaseConfigParamInput_storage_layout = CaseConfigInput(
     },
 )
 
+CaseConfigParamInput_product_quantization_PgDiskANN = CaseConfigInput(
+    label=CaseConfigParamType.product_quantization,
+    inputType=InputType.Bool,
+    displayLabel="Enable Product Quantization",
+    inputHelp="Enable product quantization to compress the index",
+    inputConfig={
+        "value": True,  
+    },
+)
+
 CaseConfigParamInput_reranking_PgDiskANN = CaseConfigInput(
     label=CaseConfigParamType.reranking,
     inputType=InputType.Bool,
     displayLabel="Enable Reranking",
-    inputHelp="Enable if you want to use reranking while performing \
-        similarity search with PQ",
+    inputHelp="Enable if you want to use reranking",
     inputConfig={
         "value": False,
     },
@@ -501,14 +510,15 @@ CaseConfigParamInput_quantized_fetch_limit_PgDiskANN = CaseConfigInput(
 CaseConfigParamInput_pq_param_num_chunks_PgDiskANN = CaseConfigInput(
     label=CaseConfigParamType.pq_param_num_chunks,
     displayLabel="pq_param_num_chunks",
-    inputHelp="Number of chunks for product quantization (Defaults to 0). 0 means it is determined automatically, based on embedding dimensions.",
+    inputHelp="Number of chunks for product quantization (Defaults to 0). "
+               "0 means it is determined automatically based on embedding dimensions.",
     inputType=InputType.Number,
     inputConfig={
         "min": 0,
         "max": 1028,
         "value": 0,
     },
-    isDisplayed=lambda config: config.get(CaseConfigParamType.reranking, False),
+    isDisplayed=lambda config: config.get(CaseConfigParamType.product_quantization, True),  
 )
 
 
@@ -2290,12 +2300,15 @@ PgVectorScalePerformanceConfig = [
 
 PgDiskANNLoadConfig = [
     CaseConfigParamInput_IndexType_PgDiskANN,
+    CaseConfigParamInput_product_quantization_PgDiskANN, 
+    CaseConfigParamInput_pq_param_num_chunks_PgDiskANN, 
     CaseConfigParamInput_max_neighbors_PgDiskANN,
     CaseConfigParamInput_l_value_ib,
 ]
 
 PgDiskANNPerformanceConfig = [
     CaseConfigParamInput_IndexType_PgDiskANN,
+    CaseConfigParamInput_product_quantization_PgDiskANN,
     CaseConfigParamInput_reranking_PgDiskANN,
     CaseConfigParamInput_max_neighbors_PgDiskANN,
     CaseConfigParamInput_l_value_ib,

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -60,6 +60,7 @@ class CaseConfigParamType(Enum):
     quantizationType = "quantization_type"
     quantizationRatio = "quantization_ratio"
     tableQuantizationType = "table_quantization_type"
+    product_quantization = "product_quantization" 
     reranking = "reranking"
     rerankingMetric = "reranking_metric"
     quantizedFetchLimit = "quantized_fetch_limit"


### PR DESCRIPTION
- Added label column to table creation schema to store categorical string labels during data load
- Implemented label-aware bulk insert using COPY to write labels alongside embeddings and IDs
- Added prepare_filter() to capture the label filter operator and value from LabelFilterPerformanceCase
- Built dynamic filtered search query with WHERE label = <value> clause for label-based vector similarity search
- Kept existing unfiltered and integer-filtered search paths intact as fallbacks