### PR TITLE
  Add Spherical Quantization Support for PgDiskANN

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ These params will vary based on the extension being used. Following two are comm
 - **`index-params`**: A set of parameters for index construction:  
   - **`max-neighbors`**	The maximum number of edges (neighbors) each node in the graph can have. Higher values improve recall at the cost of increased memory usage and indexing time.
   - **`l-value-ib`**	The parameter is used during index building, which controls the candidate list size for inserting new elements. A larger value improves recall but increases indexing time.
-  
+  - **`spherical-quantized`**	Boolean flag to enable spherical quantization on the DiskANN index (`WITH spherical_quantized`). Defaults to `false`.
+  - **`sq-bits`**	Bits per dimension for spherical quantization (`WITH sq_bits`). Typical value: `1`. Only applicable when `spherical-quantized` is enabled.
+  - **`sq-training-samples`**	Number of training samples used to compute the spherical quantization codebook (`WITH sq_training_samples`). Only applicable when `spherical-quantized` is enabled.
+
 - **`search-params`**: Parameters for search operations:
   - **`l-value-is`**: The L parameter used during search, which defines the size of the candidate neighbor list for retrieving nearest neighbors. Higher values improve recall but increase search latency.
 

--- a/benchmark_run_utils/utils.py
+++ b/benchmark_run_utils/utils.py
@@ -259,7 +259,13 @@ def get_base_command(case: dict, db_config: dict) -> list:
             base_command.append("--reranking")
         else:
             base_command.append("--skip-reranking")
-    
+
+    if "spherical-quantized" in case:
+        if case.get("spherical-quantized", False):
+            base_command.append("--spherical-quantized")
+        else:
+            base_command.append("--no-spherical-quantized")
+
     for key, value in case["index-params"].items():
         base_command.extend([f"--{key}", str(value)])
 

--- a/run.py
+++ b/run.py
@@ -20,9 +20,10 @@ os.environ["LOG_LEVEL"] = "DEBUG"
 def main():
     parser = argparse.ArgumentParser(description="Run HNSW benchmark")
     parser.add_argument("--dry-run", action="store_true", help="Print commands and output directory without executing")
+    parser.add_argument("--config", default="config.json", help="Path to config JSON file (default: config.json)")
     args = parser.parse_args()
 
-    config = load_config("config.json")
+    config = load_config(args.config)
     benchmark_info = config["benchmark-info"]
     start_time = time.time()
     start_timeh = time.strftime('%Y-%m-%d %H:%M:%S')

--- a/vectordb_bench/backend/clients/pgdiskann/cli.py
+++ b/vectordb_bench/backend/clients/pgdiskann/cli.py
@@ -18,7 +18,9 @@ from ....cli.cli import (
 class PgDiskAnnTypedDict(CommonTypedDict):
     user_name: Annotated[
         str,
-        click.option("--user-name", type=str, help="Db username", required=True),
+        click.option(
+            "--user-name", type=str, help="Db username", required=True
+        ),
     ]
     password: Annotated[
         str,
@@ -31,8 +33,12 @@ class PgDiskAnnTypedDict(CommonTypedDict):
         ),
     ]
 
-    host: Annotated[str, click.option("--host", type=str, help="Db host", required=True)]
-    db_name: Annotated[str, click.option("--db-name", type=str, help="Db name", required=True)]
+    host: Annotated[
+        str, click.option("--host", type=str, help="Db host", required=True)
+    ]
+    db_name: Annotated[
+        str, click.option("--db-name", type=str, help="Db name", required=True)
+    ]
     max_neighbors: Annotated[
         int,
         click.option(
@@ -80,7 +86,11 @@ class PgDiskAnnTypedDict(CommonTypedDict):
         click.option(
             "--reranking-metric",
             type=click.Choice(
-                [metric.value for metric in MetricType if metric.value not in ["HAMMING", "JACCARD", "DP"]],
+                [
+                    metric.value
+                    for metric in MetricType
+                    if metric.value not in ["HAMMING", "JACCARD", "DP"]
+                ],
             ),
             help="Distance metric for reranking",
             default="COSINE",
@@ -118,6 +128,34 @@ class PgDiskAnnTypedDict(CommonTypedDict):
             required=False,
         ),
     ]
+    spherical_quantized: Annotated[
+        bool,
+        click.option(
+            "--spherical-quantized/--no-spherical-quantized",
+            type=bool,
+            help="Enable spherical quantization on the diskann index (WITH spherical_quantized).",
+            default=False,
+            show_default=True,
+        ),
+    ]
+    sq_bits: Annotated[
+        int | None,
+        click.option(
+            "--sq-bits",
+            type=int,
+            help="Bits per dimension for spherical quantization (WITH sq_bits). Typical: 1.",
+            required=False,
+        ),
+    ]
+    sq_training_samples: Annotated[
+        int | None,
+        click.option(
+            "--sq-training-samples",
+            type=int,
+            help="Number of training samples for spherical quantization (WITH sq_training_samples).",
+            required=False,
+        ),
+    ]
 
 
 @cli.command()
@@ -146,6 +184,9 @@ def PgDiskAnn(
             quantized_fetch_limit=parameters["quantized_fetch_limit"],
             max_parallel_workers=parameters["max_parallel_workers"],
             maintenance_work_mem=parameters["maintenance_work_mem"],
+            spherical_quantized=parameters["spherical_quantized"],
+            sq_bits=parameters["sq_bits"],
+            sq_training_samples=parameters["sq_training_samples"],
         ),
         **parameters,
     )

--- a/vectordb_bench/backend/clients/pgdiskann/config.py
+++ b/vectordb_bench/backend/clients/pgdiskann/config.py
@@ -129,6 +129,9 @@ class PgDiskANNImplConfig(PgDiskANNIndexConfig):
     quantized_fetch_limit: int | None = None
     maintenance_work_mem: str | None = None
     max_parallel_workers: int | None = None
+    spherical_quantized: bool | None = None
+    sq_bits: int | None = None
+    sq_training_samples: int | None = None
 
     def index_param(self) -> dict:
         return {
@@ -139,6 +142,9 @@ class PgDiskANNImplConfig(PgDiskANNIndexConfig):
                 "l_value_ib": self.l_value_ib,
                 "pq_param_num_chunks": self.pq_param_num_chunks,
                 "product_quantized": str(self.reranking),
+                "spherical_quantized": self.spherical_quantized,
+                "sq_bits": self.sq_bits,
+                "sq_training_samples": self.sq_training_samples,
             },
             "maintenance_work_mem": self.maintenance_work_mem,
             "max_parallel_workers": self.max_parallel_workers,


### PR DESCRIPTION

  - Added three new CLI flags to the `pgdiskann` command: `--spherical-quantized/--no-spherical-quantized`, `--sq-bits`, and `--sq-training-samples`, wiring them through to
  `PgDiskANNImplConfig.index_param()` so they are passed as `WITH` options at index creation time
  - Fixed `get_base_command` in `benchmark_run_utils/utils.py` to handle `spherical-quantized` as a proper boolean flag (same pattern as `reranking`) — passing it as `--key value` would have
   broken Click's `--flag/--no-flag` parsing
  - Added `--config` argument to `run.py` so any config file can be targeted instead of always reading `config.json`, enabling isolated test runs without touching the main sweep config
  - Added a `config-spherical-test.json` reference config with a minimal single-case setup for validating spherical quantization runs
  - Documented all three new parameters in the `## For pg_diskann` section of `README.md`

